### PR TITLE
feat: ユーザー登録機能を有効/無効で切り替えられるフラグを実装 (#41)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,7 @@ VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 SEARCH_START_SELECT_YEAR="2022"
 COPYRIGHT_YEAR="2022"
 COPYRIGHT_NAME="laplace_p_s"
+
+# User Registration
+# Set to true to enable user registration, false to disable
+ENABLE_REGISTRATION=false

--- a/config/auth.php
+++ b/config/auth.php
@@ -102,10 +102,24 @@ return [
     |
     | Here you may define the amount of seconds before a password confirmation
     | times out and the user is prompted to re-enter their password via the
-    | confirmation screen. By default, the timeout lasts for three hours.
+    | confirmation screen. The default value is 3 hours, but it is
+    | recommended to set a shorter timeout for security reasons.
     |
     */
 
     'password_timeout' => 900,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable User Registration
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether user registration is enabled or disabled.
+    | Set this to true to allow new users to register, or false to disable
+    | the registration page.
+    |
+    */
+
+    'enable_registration' => env('ENABLE_REGISTRATION', false),
 
 ];

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -12,10 +12,13 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
-    Route::get('register', [RegisteredUserController::class, 'create'])
-                ->name('register');
+    // User registration routes - enabled/disabled by ENABLE_REGISTRATION flag
+    if (config('auth.enable_registration')) {
+        Route::get('register', [RegisteredUserController::class, 'create'])
+                    ->name('register');
 
-    Route::post('register', [RegisteredUserController::class, 'store']);
+        Route::post('register', [RegisteredUserController::class, 'store']);
+    }
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
                 ->name('login');


### PR DESCRIPTION
タイトル：
feat: ユーザー登録機能を有効/無効で切り替えられるフラグを実装 (#41)

説明：
## 概要
Issue #41 の実装です。ユーザー登録機能（/register）をフラグで有効/無効に切り替えられるようにしました。

## 実装内容

### 1. `config/auth.php` に登録有効フラグを追加
```php
'enable_registration' => env('ENABLE_REGISTRATION', false),